### PR TITLE
Mickledore Mitysom Arria10 updates

### DIFF
--- a/cooker-menu.json
+++ b/cooker-menu.json
@@ -36,14 +36,15 @@
 		},
 
 		"mitysoma10s": {
-			"target": "howto-image",
+			"target": "sdimage-mitysoma10s",
 			"layers": [
 				"meta-intel-fpga",
 				"../../../workspaces/meta-cl-mitysom",
 				"../../../workspaces/meta-howto"
 			],
 			"local.conf": [
-				"MACHINE                    = 'mitysoma10sdsc'      ",
+				"MACHINE                    = 'mitysoma10s'      ",
+				"APPLICATION_NAME           = 'howto'            ",
 				"ENABLE_UART                = '1'            "
 			]
 		}

--- a/cooker-menu.json
+++ b/cooker-menu.json
@@ -21,7 +21,7 @@
 	],
 
 	"builds" : {
-		"mitysom": {
+		"mitysom5cse": {
 			"target": "sdimage-mitysom5cse",
 			"layers": [
 				"meta-intel-fpga",
@@ -31,7 +31,20 @@
 			"local.conf": [
 				"MACHINE                    = 'mitysom5cse'      ",
 				"APPLICATION_NAME           = 'howto'            ",
-				"ENABLE_UART                = '1'                "
+				"ENABLE_UART                = '1'            "
+			]
+		},
+
+		"mitysoma10s": {
+			"target": "howto-image",
+			"layers": [
+				"meta-intel-fpga",
+				"../../../workspaces/meta-cl-mitysom",
+				"../../../workspaces/meta-howto"
+			],
+			"local.conf": [
+				"MACHINE                    = 'mitysoma10sdsc'      ",
+				"ENABLE_UART                = '1'            "
 			]
 		}
 	}

--- a/cooker-menu.json
+++ b/cooker-menu.json
@@ -45,7 +45,8 @@
 			"local.conf": [
 				"MACHINE                    = 'mitysoma10s'      ",
 				"APPLICATION_NAME           = 'howto'            ",
-				"ENABLE_UART                = '1'            "
+				"ENABLE_UART                = '1'            ",
+				"USER_KERNEL_DEVICETREE     = 'mitysom_a10s_user_empty.dtb' "
 			]
 		}
 	}

--- a/meta-howto/recipes-bsp/fpga-configuration/bitstreams-and-handoffs.bbappend
+++ b/meta-howto/recipes-bsp/fpga-configuration/bitstreams-and-handoffs.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_A10S_HPS = "mitysom_a10s_hps.xml"

--- a/meta-howto/recipes-bsp/fpga-configuration/files/README
+++ b/meta-howto/recipes-bsp/fpga-configuration/files/README
@@ -1,0 +1,5 @@
+put the split rbf files and hps.xml file generated from quartus in this directory and named in the following manner:
+
+*.core.rbf -> mitysom_a10s.core.rbf
+*.periph.rbf -> mitysom_a10s.periph.rbf
+hps.xml -> mitysom_a10s_hps.xml

--- a/meta-howto/recipes-core/images/howto-image.bb
+++ b/meta-howto/recipes-core/images/howto-image.bb
@@ -37,12 +37,6 @@ rootfs_tuning_boot() {
     rm ${IMAGE_ROOTFS}/etc/rc5.d/S15mountnfs.sh
 }
 
-IMAGE_BOOT_FILES += " \
-        fit_spl_fpga.itb \
-        mitysom_a10s.core.rbf \
-        mitysom_a10s.periph.rbf \
-        "
-
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"
 export IMAGE_BASENAME = "application-rootfs"

--- a/meta-howto/recipes-core/images/howto-image.bb
+++ b/meta-howto/recipes-core/images/howto-image.bb
@@ -37,6 +37,12 @@ rootfs_tuning_boot() {
     rm ${IMAGE_ROOTFS}/etc/rc5.d/S15mountnfs.sh
 }
 
+IMAGE_BOOT_FILES += " \
+        fit_spl_fpga.itb \
+        mitysom_a10s.core.rbf \
+        mitysom_a10s.periph.rbf \
+        "
+
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"
 export IMAGE_BASENAME = "application-rootfs"

--- a/meta-howto/recipes-kernel/linux/linux-socfpga_%.bbappend
+++ b/meta-howto/recipes-kernel/linux/linux-socfpga_%.bbappend
@@ -1,0 +1,6 @@
+SRC_URI += "file://mitysom_a10s_devkit.dtsi;subdir=git/arch/${ARCH}/boot/dts"
+SRC_URI += "file://mitysom_a10s_user_empty.dts;subdir=git/arch/${ARCH}/boot/dts"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/user-devicetrees:"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-howto/recipes-kernel/linux/user-devicetrees/mitysom_a10s_devkit.dtsi
+++ b/meta-howto/recipes-kernel/linux/user-devicetrees/mitysom_a10s_devkit.dtsi
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018 Critical Link, LLC
+ *
+ * Author: Daniel Vincelette <dvincelette@criticallink.com>
+ *
+ * Based on socfpga_arria10_socdk.dtsi
+ * Copyright (C) 2015 Altera Corporation <www.altera.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+/dts-v1/;
+#include "mitysom_a10s.dtsi"
+
+/ {
+	aliases {
+		ethernet0 = &gmac1;
+	};
+};
+
+&i2c1 {
+	status = "okay";
+
+	/* On-board Voltage Monitor */
+/* TODO: Add support
+	ad7996@29 {
+		compatible = "ad7995";
+		reg = <0x29>;
+	};
+*/
+
+	/* On-board Power Monitor Voltage Monitor 5V */
+	ltc@6e {
+		compatible = "ltc2945";
+		reg = <0x6e>;
+	};
+
+	/* On-board Power Monitor Voltage Monitor 12V */
+	ltc@6f {
+		compatible = "ltc2945";
+		reg = <0x6f>;
+	};
+};
+
+&gmac1 {
+	phy-mode = "rgmii";
+	phy-addr = <0xffffffff>; /* probe for phy addr */
+
+	/*
+	 * These skews assume the user's FPGA design is adding 600ps of delay
+	 * for TX_CLK on Arria 10.
+	 *
+	 * All skews are offset since hardware skew values for the ksz9031
+	 * range from a negative skew to a positive skew.
+	 * See the micrel-ksz90x1.txt Documentation file for details.
+	 */
+	txd0-skew-ps = <0>; /* -420ps */
+	txd1-skew-ps = <0>; /* -420ps */
+	txd2-skew-ps = <0>; /* -420ps */
+	txd3-skew-ps = <0>; /* -420ps */
+	rxd0-skew-ps = <420>; /* 0ps */
+	rxd1-skew-ps = <420>; /* 0ps */
+	rxd2-skew-ps = <420>; /* 0ps */
+	rxd3-skew-ps = <420>; /* 0ps */
+	txen-skew-ps = <0>; /* -420ps */
+	txc-skew-ps = <1860>; /* 960ps */
+	rxdv-skew-ps = <420>; /* 0ps */
+	rxc-skew-ps = <1680>; /* 780ps */
+	max-frame-size = <3800>;
+	snps,reset-gpio = <&porta 1 GPIO_ACTIVE_LOW>; 			
+	snps,reset-delays-us = <0 10000 1000000>;
+	snps,reset-active-low;
+	status = "okay";
+};
+

--- a/meta-howto/recipes-kernel/linux/user-devicetrees/mitysom_a10s_user_empty.dts
+++ b/meta-howto/recipes-kernel/linux/user-devicetrees/mitysom_a10s_user_empty.dts
@@ -1,0 +1,8 @@
+#include "mitysom_a10s_devkit.dtsi"
+// Empty dev-tree for testing
+
+&i2c0 {
+    temp@48 {
+        label = "temp48 label";
+    };
+};


### PR DESCRIPTION
Adds support for the Critical Link Mitysom Arria 10 devkit, with an additional bitstream and handoff deployment recipe.
Also adds support for user-defined device trees for the Arria 10.